### PR TITLE
Fix: docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+name: payments-api
 
 services:
   payments_api:
@@ -8,12 +8,13 @@ services:
       context: .
       dockerfile: Dockerfile
     depends_on:
-      - payments_db
+      payments_db:
+        condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: local
       AWS_ACCESS_KEY_ID: "fakekey"
       AWS_SECRET_ACCESS_KEY: "fakeaccesskey"
-      AWS_DYNAMODB_ENDPOINT: payments_db:54000
+      AWS_DYNAMODB_ENDPOINT: http://paymentsdb:54000
       AWS_REGION: us-east-1
       ADMIN_ACCESS_TOKEN: token
       MOCK_PAYMENT_PROVIDER: true
@@ -25,10 +26,16 @@ services:
     ports:
       - "8082:8082"
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8082/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   payments_db:
     image: amazon/dynamodb-local:latest
     container_name: payments_db
+    hostname: paymentsdb
     ports:
       - "54000:8000"
     environment:
@@ -36,7 +43,11 @@ services:
       AWS_SECRET_ACCESS_KEY: "fakeaccesskey"
       AWS_REGION: us-east-1
     command: ["-D\"java.library.path\"=./DynamoDBLocal_lib", "-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl localhost:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   payments_db:
-    driver: local


### PR DESCRIPTION
Before:
```bash
payments_api  | Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.amazonaws.services.dynamodbv2.AmazonDynamoDB]: Factory method 'amazonDynamoDB' threw exception with message: Endpoint does not contain a valid host name: https://payments_db:54000
```
After:
```bash
NAME           IMAGE                                COMMAND                   SERVICE        CREATED          STATUS                    PORTS
payments_api   fiap-3soat-g15-payments-api:latest   "java -jar app.jar"       payments_api   48 seconds ago   Up 26 seconds (healthy)   0.0.0.0:8082->8082/tcp
payments_db    amazon/dynamodb-local:latest         "java -D\"java.librar…"   payments_db    48 seconds ago   Up 37 seconds (healthy)   0.0.0.0:54000->8000/tcp
```